### PR TITLE
Download plugins by name

### DIFF
--- a/offline_folium/__main__.py
+++ b/offline_folium/__main__.py
@@ -1,23 +1,24 @@
 from urllib.request import urlopen
 import os
+import sys
 
 import folium
 import folium.plugins
 from .paths import dest_path
+from .plugin import handle_plugin_name
 
-def download_all_files():
+def download_all_files(plugins_name=None):
     if not os.path.exists(dest_path):
         os.makedirs(dest_path)
     for _, js_url in folium.folium._default_js:
         download_url(js_url)
     for _, js_url in folium.folium._default_css:
         download_url(js_url)
-    for plugin in [folium.plugins.BeautifyIcon]:
+    for plugin in handle_plugin_name(plugins_name):
         for _, js_url in plugin.default_css:
             download_url(js_url)
         for _, js_url in plugin.default_js:
             download_url(js_url)
-
 
 
 def download_url(url):
@@ -29,4 +30,7 @@ def download_url(url):
 
 if __name__ == "__main__":
     print(f"Downloading files to {dest_path}")
-    download_all_files()
+    if len(sys.argv) > 1:
+        download_all_files(sys.argv[1:])
+    else:
+        download_all_files()

--- a/offline_folium/offline.py
+++ b/offline_folium/offline.py
@@ -10,7 +10,7 @@ class Link(Element):
     def get_code(self):
         """Opens the link and returns the response's content."""
         if self.code is None:
-            with open(self.url, "r") as f:
+            with open(self.url, "r", encoding="utf-8") as f:
                 contents = f.read()
             self.code = contents
         return self.code

--- a/offline_folium/offline.py
+++ b/offline_folium/offline.py
@@ -3,6 +3,7 @@ from branca.element import Figure, Element, CssLink
 from jinja2 import Template
 import os
 from .paths import dest_path
+from .plugin import get_local_plugins
 
 class Link(Element):
     """An abstract class for embedding a link in the HTML."""
@@ -83,7 +84,7 @@ folium.elements.CssLink = CssLink
 
 import folium.plugins
 
-plugins = [folium.plugins.BeautifyIcon]
+plugins = get_local_plugins()
 
 for plugin in plugins:
    plugin.default_js = [

--- a/offline_folium/plugin.py
+++ b/offline_folium/plugin.py
@@ -1,0 +1,37 @@
+import pickle
+from pathlib import Path
+import folium.plugins
+from .paths import dest_path
+
+dump_plugins_path = Path(dest_path) / "plugins.download"
+
+
+def handle_plugin_name(plugins_name: list[str] | None):
+    if plugins_name is None:
+        return []
+
+    plugins = []
+    all_valid_plugins = folium.plugins.__all__
+    for name in plugins_name:
+        if name not in all_valid_plugins:
+            raise ValueError(f'"{name}" is not a valid folium plugin.')
+        plugins.append(eval(f"folium.plugins.{name}"))
+    dump_plugins_list(plugins)
+
+    return plugins
+
+
+def dump_plugins_list(plugins) -> None:
+    """Serializing for storage"""
+    with open(dump_plugins_path, "wb") as f:
+        pickle.dump(plugins, f)
+    print(f"\nDump downloaded plugins list to {dump_plugins_path}")
+
+
+def get_local_plugins():
+    if not dump_plugins_path.exists():
+        return []
+
+    with open(dump_plugins_path, "rb") as f:
+        plugins = pickle.load(f)
+    return plugins

--- a/offline_folium/plugin.py
+++ b/offline_folium/plugin.py
@@ -6,7 +6,7 @@ from .paths import dest_path
 dump_plugins_path = Path(dest_path) / "plugins.download"
 
 
-def handle_plugin_name(plugins_name: list[str] | None):
+def handle_plugin_name(plugins_name):
     if plugins_name is None:
         return []
 


### PR DESCRIPTION
1. Explicitly setting encoding to UTF-8 in `offline.py`, line 14 to fix possible UnicodeDecodeError on Windows
2. Add feature to download plugins by name, inspired by #3. Run command:
```
python -m offline_folium MeasureControl DualMap AntPath 
                                                                                                                           
Downloading files to d:\code\python\tools\offline_folium\offline_folium\local
Downloading d:\code\python\tools\offline_folium\offline_folium\local\leaflet.js
Downloading d:\code\python\tools\offline_folium\offline_folium\local\jquery-3.7.1.min.js
Downloading d:\code\python\tools\offline_folium\offline_folium\local\bootstrap.bundle.min.js
Downloading d:\code\python\tools\offline_folium\offline_folium\local\leaflet.awesome-markers.js
Downloading d:\code\python\tools\offline_folium\offline_folium\local\leaflet.css
Downloading d:\code\python\tools\offline_folium\offline_folium\local\bootstrap.min.css
Downloading d:\code\python\tools\offline_folium\offline_folium\local\bootstrap-glyphicons.css
Downloading d:\code\python\tools\offline_folium\offline_folium\local\all.min.css
Downloading d:\code\python\tools\offline_folium\offline_folium\local\leaflet.awesome-markers.css
Downloading d:\code\python\tools\offline_folium\offline_folium\local\leaflet.awesome.rotate.min.css

Dump downloaded plugins list to d:\code\python\tools\offline_folium\offline_folium\local\plugins.download
Downloading d:\code\python\tools\offline_folium\offline_folium\local\leaflet-measure.min.css
Downloading d:\code\python\tools\offline_folium\offline_folium\local\leaflet-measure.min.js
Downloading d:\code\python\tools\offline_folium\offline_folium\local\L.Map.Sync.min.js
Downloading d:\code\python\tools\offline_folium\offline_folium\local\leaflet-ant-path.min.js
```