### PR TITLE
installation: Fix missing `pkg_resources`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,23 @@
 `offline_folium` is a Python module that makes it possible to use [folium](https://python-visualization.github.io/folium/) without an internet connection.
 
 ## Quickstart
-- Install offline_folium (`pip install offline_folium`)
-- When you have an internet connection, download the relevant Javascript/CSS by running `python -m offline_folium`
-- When you do not have an internet connection, run `from offline_folium import offline` _before_ you import folium, and then use folium normally. For example:
+- Install offline_folium:
 
+```bash
+pip install offline_folium
 ```
+
+- When you have an internet connection, download the relevant Javascript/CSS by running:
+```bash
+python -m offline_folium
+```
+- When you do not have an internet connection, run
+```python
+from offline_folium import offline
+```
+ _before_ you import folium, and then use `folium` normally. For example:
+
+```python
 from offline_folium import offline
 import folium
 

--- a/offline_folium/__main__.py
+++ b/offline_folium/__main__.py
@@ -28,9 +28,13 @@ def download_url(url):
     with open(output_path, "w", encoding='utf-8') as f:
         f.write(contents)
 
-if __name__ == "__main__":
+def main():
+    """Main entry point for the offline-folium command."""
     print(f"Downloading files to {dest_path}")
     if len(sys.argv) > 1:
         download_all_files(sys.argv[1:])
     else:
         download_all_files()
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
     author='Robin Wilson',
     author_email='robin@rtwilson.com',
     description='Allows using folium with no internet connection',
-    packages=find_packages('.'),    
-    install_requires=['folium'],
+    packages=find_packages('.'),
+    install_requires=['folium', 'setuptools<81'],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
 from setuptools import setup, find_packages
 
+# Read the README file for the long description
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
 setup(
     name='offline_folium',
     version='0.1',
@@ -7,6 +11,16 @@ setup(
     author='Robin Wilson',
     author_email='robin@rtwilson.com',
     description='Allows using folium with no internet connection',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     packages=find_packages('.'),
-    install_requires=['folium', 'setuptools<81'],
+    include_package_data=True,
+    package_data={
+        'offline_folium': ['local/*'],
+    },
+    install_requires=[
+        'folium',
+        'setuptools<81',
+        'requests',
+    ],
 )


### PR DESCRIPTION
Hi! Thank you for this package!
I use it for plotting geo-data in an internet-constrained environment.
I am contributing this PR as I encountered two issues, that I think need to be fixed.
First, `setuptools` is not a package requirement, and as a result when installing this package in a new python env,
I get:

```bash
gb4018@titaros:~/workspace/offline_folium$ python -m offline_folium
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/gb4018/workspace/offline_folium/offline_folium/__main__.py", line 7, in <module>
    from .paths import dest_path
  File "/home/gb4018/workspace/offline_folium/offline_folium/paths.py", line 1, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Secondly, the latest setuptools does not favot the use of pkg_resources:

```bash
gb4018@titaros:~/workspace/offline_folium$ python -m offline_folium
/home/gb4018/workspace/offline_folium/offline_folium/paths.py:1: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
```

Thus, I restricted the installation of the package in `setuptools<81`.

Users should be able to follow the same procedure, as already shown in README.md with zero changes.

Happy to get feedback on how to further improve this PR.

Best regards,
George



